### PR TITLE
Disconnect Winston network from main Ethereum network

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -23,7 +23,7 @@ devp2p subprotocols by abstracting away code standardly shared by protocols.
 * provide the forever loop to read incoming messages
 * standardise error handling related to communication
 * standardised	handshake negotiation
-* TODO: automatic generation of wire protocol specification for peers 
+* TODO: automatic generation of wire protocol specification for peers
 
 */
 package protocols

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -23,7 +23,7 @@ devp2p subprotocols by abstracting away code standardly shared by protocols.
 * provide the forever loop to read incoming messages
 * standardise error handling related to communication
 * standardised	handshake negotiation
-* TODO: automatic generation of wire protocol specification for peers
+* TODO: automatic generation of wire protocol specification for peers 
 
 */
 package protocols

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -154,6 +154,9 @@ type Config struct {
 
 	// Logger is a custom logger to use with the p2p.Server.
 	Logger log.Logger `toml:",omitempty"`
+
+	// Set to assign a unique network id.
+	NetworkId 	string
 }
 
 // Server manages all peer connections.
@@ -550,8 +553,9 @@ func (srv *Server) setupDiscovery() error {
 			NetRestrict: srv.NetRestrict,
 			Bootnodes:   srv.BootstrapNodes,
 			Unhandled:   unhandled,
+			NetworkId:   []byte(srv.NetworkId),
 		}
-		//fmt.Println("[DEBUG] setupDiscovery() Listening on disc v4", conn)
+		//fmt.Println("[DEBUG] setupDiscovery() Listening on disc v4", conn, "network id", srv.NetworkId)
 		ntab, err := discover.ListenUDP(conn, srv.localnode, cfg)
 		if err != nil {
 			return err
@@ -753,8 +757,7 @@ running:
 					p.events = &srv.peerFeed
 				}
 				name := truncateName(c.name)
-				//fmt.Printf("  *** run() <- addpeer - c: %+v  peer: %+v\n", c, p)
-				//fmt.Println("  *** Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
+				//fmt.Println("[DEBUG] Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
 				srv.log.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
 				go srv.runPeer(p)
 				peers[c.node.ID()] = p
@@ -961,6 +964,7 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *enode.Node) 
 }
 
 func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) error {
+	//fmt.Println("[DEBUG] setupConn()", "remote addr", c.fd.RemoteAddr(),)
 	// Prevent leftover pending conns from entering the handshake.
 	srv.lock.Lock()
 	running := srv.running


### PR DESCRIPTION
This patch disables discovery between Winston nodes and the main Ethereum network.

After merging, any node running this code will no longer be able to discover legacy Winston nodes, though they will still be able to communicate with previously discovered peers.